### PR TITLE
Update std to 0.75.0 for Deno 1.5.0 compat

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -2,6 +2,6 @@ export {
   findIndex,
   concat,
   repeat,
-} from "https://deno.land/std@0.61.0/bytes/mod.ts";
-export { getLogger } from "https://deno.land/std@0.61.0/log/mod.ts";
-export { Logger } from "https://deno.land/std@0.61.0/log/logger.ts";
+} from "https://deno.land/std@0.75.0/bytes/mod.ts";
+export { getLogger } from "https://deno.land/std@0.75.0/log/mod.ts";
+export { Logger } from "https://deno.land/std@0.75.0/log/logger.ts";

--- a/dev_deps.ts
+++ b/dev_deps.ts
@@ -1,5 +1,5 @@
 export {
   assertEquals,
   assertThrowsAsync,
-} from "https://deno.land/std@0.61.0/testing/asserts.ts";
-export * as log from "https://deno.land/std@0.61.0/log/mod.ts";
+} from "https://deno.land/std@0.75.0/testing/asserts.ts";
+export * as log from "https://deno.land/std@0.75.0/log/mod.ts";


### PR DESCRIPTION
It seems like [Deno 1.5.0's stricter Typescript setting](https://deno.land/posts/v1.5) break the older std versions:

```
> deno cache https://deno.land/x/csv@v0.4.0/mod.ts
Check https://deno.land/x/csv@v0.4.0/mod.ts
error: TS1205 [ERROR]: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
export { LogLevels, LevelName } from "./levels.ts";
                    ~~~~~~~~~
    at https://deno.land/std@0.61.0/log/mod.ts:13:21
```

So I've simply updated std to latest, and it seems to work fine again.