### PR TITLE
Add support for custom encoding

### DIFF
--- a/reader.ts
+++ b/reader.ts
@@ -6,6 +6,7 @@ export interface CommonCSVReaderOptions {
   columnSeparator: string | Uint8Array;
   lineSeparator: string | Uint8Array;
   quote: string | Uint8Array;
+  encoding?: string;
 }
 
 /** Options for CSVReader class */
@@ -107,7 +108,7 @@ export class CSVReader {
   private lastLineStartPos: number;
 
   constructor(reader: Deno.Reader, options?: Partial<CSVReaderOptions>) {
-    this.decoder = new TextDecoder();
+    this.decoder = new TextDecoder(options?.encoding);
     const mergedOptions: HiddenCSVReaderOptions = {
       ...defaultCSVReaderOptions,
       ...options,


### PR DESCRIPTION
This PR makes it possible to pass encoding option for TextDecoder, used internally, to make it possible to read CSV files in different encodings