### PR TITLE
fix(lines): toLine is exclusive

### DIFF
--- a/reader.ts
+++ b/reader.ts
@@ -319,8 +319,9 @@ export class CSVReader {
         continue;
       }
 
+      // linesProcessed start at 1 and toLine at 0
       // stop reading if toLine is reached
-      if (!this.inColumn && this.linesProcessed > this.toLine) {
+      if (!this.inColumn && this.linesProcessed >= this.toLine) {
         this.debug("eof");
         this.onEnd();
         return;

--- a/reader_test.ts
+++ b/reader_test.ts
@@ -361,9 +361,49 @@ g,h`,
     );
 
     const rows = await asyncArrayFrom(
-      readCSVRows(reader, { fromLine: 1, toLine: 2 }),
+      readCSVRows(reader, { fromLine: 1, toLine: 3 }),
     );
 
     assertEquals(rows, [["c", "d"], ["e", "f"]]);
+  },
+});
+
+Deno.test({
+  name: "readCSVRows options.toLine should be exclusive",
+  async fn() {
+    const reader = new MyReader(
+      `a,b
+c,d
+e,f
+g,h`,
+    );
+
+    const rows = await asyncArrayFrom(
+      readCSVRows(reader, { fromLine: 1, toLine: 2 }),
+    );
+
+    assertEquals(rows, [["c", "d"]]);
+  },
+});
+
+Deno.test({
+  name: "readCSVRows can read only the first line",
+  async fn() {
+    const reader = new MyReader(
+      `1,2,3
+a,b,c
+!,@,#`,
+    );
+
+    const rows = await asyncArrayFrom(
+      readCSVRows(reader, {
+        fromLine: 0,
+        toLine: 1,
+      }),
+    );
+
+    assertEquals(rows, [
+      ["1", "2", "3"],
+    ]);
   },
 });


### PR DESCRIPTION
Fixes #19 

The `toLine` option was not exclusive as said in the documentation which prevented to do the following to read only the first line.

```js
const readIterable = readCSV(file, {
    fromLine: 0,
    toLine: 1,
  });
```

Two tests where added and one test updated to match the documentation.
