### PR TITLE
Fixing issue #23

### DIFF
--- a/reader.ts
+++ b/reader.ts
@@ -626,20 +626,17 @@ class CSVRowReader implements AsyncIterableIterator<string[]> {
   }
 
   private onCell(cell: string) {
-    console.log(`On cell: ${cell}`);
     this.row.push(cell);
   }
 
   private onRowEnd() {
     const row = this.row;
     this.row = [];
-    console.log(`On row end`, row);
     this.process({ done: false, value: row });
   }
 
   private onEnd() {
     this.done = true;
-    console.log(`On end`);
     this.process({ done: true, value: undefined });
   }
 

--- a/reader.ts
+++ b/reader.ts
@@ -189,6 +189,7 @@ export class CSVReader {
   }
 
   private processColumn() {
+    this.emptyLine = false;
     const result = this.decoder.decode(
       this.columnBuffer.subarray(0, this.columnBufferIndex),
     );
@@ -625,17 +626,20 @@ class CSVRowReader implements AsyncIterableIterator<string[]> {
   }
 
   private onCell(cell: string) {
+    console.log(`On cell: ${cell}`);
     this.row.push(cell);
   }
 
   private onRowEnd() {
     const row = this.row;
     this.row = [];
+    console.log(`On row end`, row);
     this.process({ done: false, value: row });
   }
 
   private onEnd() {
     this.done = true;
+    console.log(`On end`);
     this.process({ done: true, value: undefined });
   }
 

--- a/reader_test.ts
+++ b/reader_test.ts
@@ -421,3 +421,22 @@ a,b,c
     assertEquals(rows, [["1", "2", "3"]]);
   },
 });
+
+Deno.test({
+  name: "readCSVRows can read empty lines (not prepends to the next line)",
+  async fn() {
+    const reader = new MyReader(
+      `col1,col2,col3
+a,b,c
+,,
+d,e,f`
+    );
+    const rows = await asyncArrayFrom(readCSVRows(reader));
+    assertEquals(rows, [
+      ["col1", "col2", "col3"],
+      ["a", "b", "c"],
+      ["", "", ""],
+      ["d", "e", "f"]
+    ])
+  }
+})


### PR DESCRIPTION
Pull request for #23.

You manage the `emptyLine` state in `CSVReader`, but in case of column-separator presence this property should be set to false.

Test has been also added.

