### PR TITLE
Use `readonly string[]` for header in `writeCSVObjects`

### DIFF
--- a/writer.ts
+++ b/writer.ts
@@ -196,7 +196,7 @@ export async function writeCSVObjects(
   writer: Deno.Writer,
   iter: SyncAsyncIterable<{ [key: string]: string }>,
   options: Partial<CSVWriterOptions & CSVWriteCellOptions> & {
-    header: string[];
+    header: readonly string[];
   },
 ) {
   const { header } = options;

--- a/writer_test.ts
+++ b/writer_test.ts
@@ -101,3 +101,19 @@ Deno.test({
     assertEquals(new TextDecoder().decode(buf.bytes()), `a,b,c\n1,2,3\n4,5,6`);
   },
 });
+
+Deno.test({
+  name: "writeCSVObjects can use readonly header",
+  async fn() {
+    const buf = new Buffer();
+    const header = ["a", "b", "c"] as const;
+    const asyncRows = async function* () {
+      yield { a: "1", b: "2", c: "3" };
+      yield { a: "4", b: "5", c: "6" };
+    };
+
+    await writeCSVObjects(buf, asyncRows(), { header });
+
+    assertEquals(new TextDecoder().decode(buf.bytes()), `a,b,c\n1,2,3\n4,5,6`);
+  },
+});


### PR DESCRIPTION
Currently passing `header` of type `readonly string[]` fails. Since `writeCSVObjects` doesn't mutate the `header` parameter, it's safe for it to be `readonly`.

This means that a `header` parameter specified with `as const` can be passed directly to `writeCSVObjects` like this:
```ts
const header = [
  "a", "b", "c",
] as const;

await writeCSVObjects(buf, rows, { header });
```

rather than having to create a mutable copy of the `header` array:

```ts
await writeCSVObjects(buf, rows, { header: [...header] });
```